### PR TITLE
Opening documents when target is x86 fails with access violation

### DIFF
--- a/PDFiumSharp/PDFiumSharp.csproj
+++ b/PDFiumSharp/PDFiumSharp.csproj
@@ -5,13 +5,23 @@
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <AssemblyVersion>0.1.2.0</AssemblyVersion>
     <Copyright>Copyright © Tobias Meyer 2017</Copyright>
+    <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DocumentationFile>bin\Release\netstandard1.4\PDFiumSharp.xml</DocumentationFile>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <DocumentationFile>bin\Release\netstandard1.4\PDFiumSharp.xml</DocumentationFile>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/PDFiumSharp/PdfPageCollection.cs
+++ b/PDFiumSharp/PdfPageCollection.cs
@@ -22,7 +22,11 @@ namespace PDFiumSharp
 		{
 			_doc = doc;
 			_pages = new List<PdfPage>(PDFium.FPDF_GetPageCount(doc.Handle));
-		}
+
+            //Initialize _pages with null entries
+            for(int i=this.Count;i>0;i--)
+                _pages.Add(null);
+        }
 
 		/// <summary>
 		/// Gets the number of pages in the <see cref="PdfDocument"/>.
@@ -38,11 +42,7 @@ namespace PDFiumSharp
 			{
 				if (index >= _pages.Count)
 				{
-					int count = this.Count;
-					if (index >= count)
-						throw new ArgumentOutOfRangeException(nameof(index));
-					while (_pages.Count < count)
-						_pages.Add(null);
+					throw new ArgumentOutOfRangeException(nameof(index));
 				}
 
 				if (_pages[index] == null || _pages[index].IsDisposed)
@@ -60,13 +60,13 @@ namespace PDFiumSharp
 
 		IEnumerator<PdfPage> IEnumerable<PdfPage>.GetEnumerator()
 		{
-			for (int i = 0; i < Count; i++)
+			for (int i = 0; i < _pages.Count; i++)
 				yield return this[i];
 		}
 
 		IEnumerator IEnumerable.GetEnumerator()
 		{
-			for (int i = 0; i < Count; i++)
+			for (int i = 0; i < _pages.Count; i++)
 				yield return this[i];
 		}
 
@@ -76,16 +76,24 @@ namespace PDFiumSharp
 		/// <seealso cref="PDFium.FPDF_ImportPages(Types.FPDF_DOCUMENT, Types.FPDF_DOCUMENT, int, int[])"/>
 		public bool Insert(int index, PdfDocument sourceDocument, params int[] srcPageIndices)
 		{
-			if (index < _pages.Count)
-				_pages.Insert(index, null);
-			var result = PDFium.FPDF_ImportPages(_doc.Handle, sourceDocument.Handle, index, srcPageIndices);
-			_pages.InsertRange(index, Enumerable.Repeat<PdfPage>(null, srcPageIndices.Length));
-			for (int i = index; i < _pages.Count; i++)
-			{
-				if (_pages[i] != null)
-					_pages[i].Index = i;
-			}
-			return result;
+            bool result = false;
+            if (index <= _pages.Count)
+            {
+                result = PDFium.FPDF_ImportPages(_doc.Handle, sourceDocument.Handle, index, srcPageIndices);
+                if (result)
+                {
+                    _pages.InsertRange(index, Enumerable.Repeat<PdfPage>(null, srcPageIndices.Length));
+                    for (int i = index; i < _pages.Count; i++)
+                    {
+                        if (_pages[i] != null)
+                            _pages[i].Index = i;
+                    }
+                }
+            }
+            else
+                throw new ArgumentOutOfRangeException(nameof(index));
+
+            return result;
 		}
 
 		/// <summary>
@@ -102,20 +110,21 @@ namespace PDFiumSharp
 		/// </summary>
 		public PdfPage Insert(int index, double width, double height)
 		{
-			if (index < _pages.Count)
+            PdfPage page=null;
+            if (index <= _pages.Count)
 			{
-				_pages.Insert(index, null);
+                page = PdfPage.New(_doc, index, width, height);
+                _pages.Insert(index, page);
 				for (int i = index; i < _pages.Count; i++)
 				{
 					if (_pages[i] != null)
 						_pages[i].Index = i;
 				}
 			}
-			var page = PdfPage.New(_doc, index, width, height);
-			while (_pages.Count <= index)
-				_pages.Add(null);
-			_pages[index] = page;
-			return page;
+            else
+                throw new ArgumentOutOfRangeException(nameof(index));
+
+            return page;
 		}
 
 		/// <summary>

--- a/PDFiumSharp/Types/FPDF_FILEACCESS.cs
+++ b/PDFiumSharp/Types/FPDF_FILEACCESS.cs
@@ -11,8 +11,10 @@ using System.IO;
 
 namespace PDFiumSharp.Types
 {
-	public delegate bool FileReadBlockHandler(IntPtr ignore, int position, IntPtr buffer, int size);
-	public delegate bool FileWriteBlockHandler(IntPtr ignore, IntPtr data, int size);
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate bool FileReadBlockHandler(IntPtr ignore, int position, IntPtr buffer, int size);
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate bool FileWriteBlockHandler(IntPtr ignore, IntPtr data, int size);
 
 	[StructLayout(LayoutKind.Sequential)]
     public class FPDF_FILEREAD
@@ -33,7 +35,7 @@ namespace PDFiumSharp.Types
 
 		public static FPDF_FILEREAD FromStream(Stream stream, int count = 0)
 		{
-			if (count < 0)
+			if (count <= 0)
 				count = (int)(stream.Length - stream.Position);
 			var start = stream.Position;
 			byte[] data = null;


### PR DESCRIPTION
I added [UnmanagedFunctionPointer(CallingConvention.Cdecl)] to the delegates in FPDF_FILEACCESS.cs so they will be called properly from x86. 
Modified FromStream to allow count = 0 to calculate the stream length. Previously when sending count = 0, you would get an error about it not being a pdf.